### PR TITLE
test: add wiremock integration tests for responses endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,31 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -182,6 +201,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,12 +285,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -261,6 +314,40 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -274,8 +361,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -309,6 +401,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +430,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -366,6 +483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,9 +498,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -646,6 +771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +833,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +865,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -896,6 +1038,35 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -1380,6 +1551,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1894,6 +2078,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ thiserror = { version = "2", optional = true }
 [dev-dependencies]
 # Used for async unit tests of the client module.
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,83 @@
+use wiremock::MockServer;
+
+/// Starts a dedicated [`MockServer`] that is **not** drawn from the global pool.
+///
+/// Using [`MockServer::builder().start()`] instead of [`MockServer::start()`]
+/// ensures each test gets its own isolated server instance, avoiding shared
+/// state that can cause leaky / flaky tests.
+pub async fn mock_server() -> MockServer {
+    MockServer::builder().start().await
+}
+
+/// Builds an [`ores::client::Client`] whose base URL points at the given mock
+/// server so that all HTTP traffic stays local.
+pub fn test_client(server: &MockServer) -> ores::client::Client {
+    let base_url = url::Url::parse(&server.uri()).expect("mock server URI should be a valid URL");
+    ores::client::Client::builder("test-api-key", base_url)
+        .build()
+        .expect("client builder should not fail with valid inputs")
+}
+
+/// Returns a minimal, valid JSON body representing a successful
+/// `ResponseResource` from the API.
+///
+/// The caller can layer additional fields on top via `serde_json::Value`
+/// mutation if a test needs custom output items, errors, etc.
+pub fn success_response_body() -> serde_json::Value {
+    serde_json::json!({
+        "id": "resp_test_123",
+        "object": "response",
+        "created_at": 1700000000,
+        "completed_at": 1700000001,
+        "status": "completed",
+        "incomplete_details": null,
+        "model": "gpt-test",
+        "previous_response_id": null,
+        "instructions": null,
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_test_001",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Hello from the mock!",
+                        "annotations": [],
+                        "logprobs": []
+                    }
+                ]
+            }
+        ],
+        "error": null,
+        "tools": [],
+        "tool_choice": null,
+        "truncation": "disabled",
+        "parallel_tool_calls": false,
+        "text": {
+            "format": { "type": "text" }
+        },
+        "top_p": 1.0,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "top_logprobs": 0,
+        "temperature": 1.0,
+        "reasoning": null,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "input_tokens_details": { "cached_tokens": 0 },
+            "output_tokens_details": { "reasoning_tokens": 0 }
+        },
+        "max_output_tokens": null,
+        "max_tool_calls": null,
+        "store": false,
+        "background": false,
+        "service_tier": "default",
+        "metadata": {},
+        "safety_identifier": null,
+        "prompt_cache_key": null
+    })
+}

--- a/tests/responses.rs
+++ b/tests/responses.rs
@@ -1,0 +1,314 @@
+mod common;
+
+use wiremock::matchers::{bearer_token, body_partial_json, header, method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Happy-path tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_response_returns_parsed_resource() {
+    let server = common::mock_server().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .and(header("content-type", "application/json"))
+        .and(bearer_token("test-api-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::success_response_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let resp = client
+        .responses()
+        .create_text("gpt-test", "Say hello")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.id, "resp_test_123");
+    assert_eq!(resp.object, "response");
+    assert_eq!(resp.status, "completed");
+    assert_eq!(resp.model, "gpt-test");
+    assert!(resp.usage.is_some());
+
+    let usage = resp.usage.unwrap();
+    assert_eq!(usage.input_tokens, 10);
+    assert_eq!(usage.output_tokens, 5);
+    assert_eq!(usage.total_tokens, 15);
+}
+
+#[tokio::test]
+async fn create_response_sends_correct_request_body() {
+    let server = common::mock_server().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .and(body_partial_json(serde_json::json!({
+            "model": "gpt-test",
+            "input": "Say hello",
+            "stream": false,
+            "store": false
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::success_response_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    client
+        .responses()
+        .create_text("gpt-test", "Say hello")
+        .send()
+        .await
+        .expect("request should succeed");
+}
+
+#[tokio::test]
+async fn create_response_with_optional_params() {
+    let server = common::mock_server().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::success_response_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let resp = client
+        .responses()
+        .create_text("gpt-test", "Say hello")
+        .temperature(0.5)
+        .max_output_tokens(100)
+        .instructions("Be concise")
+        .top_p(0.9)
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.id, "resp_test_123");
+}
+
+// ---------------------------------------------------------------------------
+// Error-path tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn returns_http_status_error_on_401() {
+    let server = common::mock_server().await;
+    let error_body = serde_json::json!({
+        "error": {
+            "message": "Invalid API key",
+            "type": "authentication_error",
+            "code": "invalid_api_key"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(error_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let err = client
+        .responses()
+        .create_text("gpt-test", "hello")
+        .send()
+        .await
+        .expect_err("should return an error for 401");
+
+    match err {
+        ores::client::Error::HttpStatus { status, body } => {
+            assert_eq!(status.as_u16(), 401);
+            assert!(body.contains("invalid_api_key"), "body was: {body}");
+        }
+        other => panic!("expected HttpStatus error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn returns_http_status_error_on_400() {
+    let server = common::mock_server().await;
+    let error_body = serde_json::json!({
+        "error": {
+            "message": "Invalid request: model is required",
+            "type": "invalid_request_error",
+            "code": "invalid_request"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(error_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let err = client
+        .responses()
+        .create_text("gpt-test", "hello")
+        .send()
+        .await
+        .expect_err("should return an error for 400");
+
+    match err {
+        ores::client::Error::HttpStatus { status, body } => {
+            assert_eq!(status.as_u16(), 400);
+            assert!(body.contains("invalid_request"), "body was: {body}");
+        }
+        other => panic!("expected HttpStatus error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn returns_http_status_error_on_500() {
+    let server = common::mock_server().await;
+    let error_body = serde_json::json!({
+        "error": {
+            "message": "Internal server error",
+            "type": "server_error",
+            "code": "server_error"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(error_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let err = client
+        .responses()
+        .create_text("gpt-test", "hello")
+        .send()
+        .await
+        .expect_err("should return an error for 500");
+
+    match err {
+        ores::client::Error::HttpStatus { status, body } => {
+            assert_eq!(status.as_u16(), 500);
+            assert!(body.contains("server_error"), "body was: {body}");
+        }
+        other => panic!("expected HttpStatus error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn returns_http_status_error_on_429_rate_limit() {
+    let server = common::mock_server().await;
+    let error_body = serde_json::json!({
+        "error": {
+            "message": "Rate limit exceeded",
+            "type": "rate_limit_error",
+            "code": "rate_limit_exceeded"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(error_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let err = client
+        .responses()
+        .create_text("gpt-test", "hello")
+        .send()
+        .await
+        .expect_err("should return an error for 429");
+
+    match err {
+        ores::client::Error::HttpStatus { status, body } => {
+            assert_eq!(status.as_u16(), 429);
+            assert!(body.contains("rate_limit_exceeded"), "body was: {body}");
+        }
+        other => panic!("expected HttpStatus error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn returns_error_on_invalid_json_response() {
+    let server = common::mock_server().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("this is not json"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let err = client
+        .responses()
+        .create_text("gpt-test", "hello")
+        .send()
+        .await
+        .expect_err("should return an error for invalid JSON");
+
+    // reqwest surfaces deserialization failures as its own error type
+    assert!(
+        matches!(err, ores::client::Error::Reqwest(_)),
+        "expected Reqwest error, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn returns_http_status_error_with_empty_body() {
+    let server = common::mock_server().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(502))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = common::test_client(&server);
+    let err = client
+        .responses()
+        .create_text("gpt-test", "hello")
+        .send()
+        .await
+        .expect_err("should return an error for 502");
+
+    match err {
+        ores::client::Error::HttpStatus { status, body } => {
+            assert_eq!(status.as_u16(), 502);
+            assert!(body.is_empty(), "expected empty body, got: {body}");
+        }
+        other => panic!("expected HttpStatus error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unmatched_request_returns_error() {
+    // When wiremock has no matching mock, it responds with 404.
+    // The client should surface that as an HttpStatus error.
+    let server = common::mock_server().await;
+    // Intentionally mount no mocks.
+
+    let client = common::test_client(&server);
+    let err = client
+        .responses()
+        .create_text("gpt-test", "hello")
+        .send()
+        .await
+        .expect_err("should return an error when no mock matches");
+
+    match err {
+        ores::client::Error::HttpStatus { status, .. } => {
+            assert_eq!(status.as_u16(), 404);
+        }
+        other => panic!("expected HttpStatus error, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
Set up integration test infrastructure with wiremock using dedicated
(non-pooled) mock servers to prevent test isolation issues. Tests cover
the happy path (successful response creation, request body verification,
optional parameters) and error paths (401, 400, 429, 500, empty body,
invalid JSON, unmatched route).

https://claude.ai/code/session_01X7p5MXutW3eNs424snJcKz