### PR TITLE
Align streaming types and add streaming variants in type relationship graph

### DIFF
--- a/crates/schelm-ores/src/models/type_relationships.dot
+++ b/crates/schelm-ores/src/models/type_relationships.dot
@@ -415,6 +415,17 @@ ResponseContentPartAdded { part }<BR ALIGN="LEFT"/>
 ResponseContentPartDone { part }<BR ALIGN="LEFT"/>
 ResponseOutputTextDelta { delta, logprobs }<BR ALIGN="LEFT"/>
 ResponseOutputTextDone { text, logprobs }<BR ALIGN="LEFT"/>
+ResponseReasoningSummaryPartAdded { part }<BR ALIGN="LEFT"/>
+ResponseReasoningSummaryPartDone { part }<BR ALIGN="LEFT"/>
+ResponseRefusalDelta { delta }<BR ALIGN="LEFT"/>
+ResponseRefusalDone { refusal }<BR ALIGN="LEFT"/>
+ResponseReasoningDelta { delta }<BR ALIGN="LEFT"/>
+ResponseReasoningDone { text }<BR ALIGN="LEFT"/>
+ResponseReasoningSummaryDelta { delta }<BR ALIGN="LEFT"/>
+ResponseReasoningSummaryDone { text }<BR ALIGN="LEFT"/>
+ResponseOutputTextAnnotationAdded { annotation }<BR ALIGN="LEFT"/>
+ResponseFunctionCallArgumentsDelta { delta }<BR ALIGN="LEFT"/>
+ResponseFunctionCallArgumentsDone { arguments }<BR ALIGN="LEFT"/>
 Error { error }<BR ALIGN="LEFT"/>
 </FONT></TD></TR>
 </TABLE>>];
@@ -1080,6 +1091,7 @@ headers : Map&lt;String, String&gt;?<BR ALIGN="LEFT"/>
     StreamingEvent -> ResponseResource [style=dashed, color="#0891B2", constraint=false];
     StreamingEvent -> ItemField [style=dashed, color="#0891B2", constraint=false];
     StreamingEvent -> MessageContentPart [style=dashed, color="#0891B2", constraint=false];
+    StreamingEvent -> Annotation [style=dashed, color="#0891B2", constraint=false];
     StreamingEvent -> LogProb [style=dashed, color="#0891B2", constraint=false];
     StreamingEvent -> ErrorPayload [weight=5, color="#0891B2"];
 
@@ -1113,11 +1125,11 @@ headers : Map&lt;String, String&gt;?<BR ALIGN="LEFT"/>
     {rank=same; InputTextContent; OutputTextContent; TextContent; SummaryTextContent; ReasoningTextContent; RefusalContent; InputImageContent; InputFileContent;}
 
     // Annotations and logprobs
-    {rank=same; Annotation; LogProb; UrlCitationParam;}
+    {rank=same; UrlCitationParam;}
     {rank=same; UrlCitationBody; TopLogProb;}
 
     // Streaming at the bottom
-    {rank=same; StreamingEvent; ErrorPayload;}
+    {rank=same; StreamingEvent; Annotation; LogProb; ErrorPayload;}
 
     // Token details together
     {rank=same; InputTokensDetails; OutputTokensDetails;}


### PR DESCRIPTION
### Motivation
- Keep the Graphviz type relationship diagram consistent with newly-introduced streaming event variants and reduce long crossing edges by improving placement of streaming-related nodes.
- Ensure streaming-related types (annotations, logprobs, and error payloads) are visually colocated so the diagram better reflects relationships between streaming events and their payloads.

### Description
- Added the new streaming variants to the `StreamingEvent` card in `crates/schelm-ores/src/models/type_relationships.dot` so the diagram lists the new event kinds alongside existing streaming events.
- Added a dashed edge `StreamingEvent -> Annotation` with streaming styling so `ResponseOutputTextAnnotationAdded` is represented in the relationships section.
- Adjusted layout constraints by removing `Annotation` and `LogProb` from the earlier annotation/logprob rank and placing `StreamingEvent`, `Annotation`, `LogProb`, and `ErrorPayload` together in the bottom rank to keep streaming-related types close.
- Simplified the prior annotation rank grouping to avoid long cross-graph edges and preserve the existing table/card layout and legend grouping.

### Testing
- Ran `cargo check -p schelm-ores` which completed successfully.
- Executed a small validation script comparing `StreamingEvent` enum variants in `mod.rs` against entries in `type_relationships.dot` and found no missing or extra entries (counts matched).
- Attempted `just check` and `just test` but `just` is not installed in this environment, so those checks were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999838a9e50832e85fc8af002b90b42)