### PR TITLE
Simplify Stream polling using as_mut() instead of Pin::new()

### DIFF
--- a/crates/schelm-ores/src/client/sse.rs
+++ b/crates/schelm-ores/src/client/sse.rs
@@ -259,7 +259,7 @@ impl Stream for ResponseEventStream {
             }
 
             // Need more data — poll the inner stream
-            match Pin::new(&mut this.inner).poll_next(cx) {
+            match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(chunk))) => {
                     this.buf.extend_from_slice(&chunk);
 


### PR DESCRIPTION
## Summary
Refactored the `ResponseEventStream` implementation to use a more idiomatic approach for polling the inner stream.

## Key Changes
- Replaced `Pin::new(&mut this.inner).poll_next(cx)` with `this.inner.as_mut().poll_next(cx)` in the `poll_next` implementation
- This simplification leverages the fact that `this.inner` is already pinned (as `this` is a pinned reference), making the explicit `Pin::new()` wrapper unnecessary

## Implementation Details
Since `this` is already a pinned mutable reference to `Self` (from the `Pin<&mut Self>` parameter), calling `as_mut()` on the inner stream field provides the necessary pinned mutable reference without the overhead of creating a new `Pin` wrapper. This is both more idiomatic and clearer in intent.

https://claude.ai/code/session_011JYm7zHkPeohpnct94jgvG